### PR TITLE
1st update of MonsterAI can't take RunState as it's not embedded yet

### DIFF
--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -614,7 +614,7 @@ Now we modify the `monster_ai_system`. There's a bit of clean-up here, and the "
 
 ```rust
 use specs::prelude::*;
-use super::{Viewshed, Monster, Map, Position, WantsToMelee, RunState};
+use super::{Viewshed, Monster, Map, Position, WantsToMelee};
 use rltk::{Point};
 
 pub struct MonsterAI {}
@@ -624,7 +624,6 @@ impl<'a> System<'a> for MonsterAI {
     type SystemData = ( WriteExpect<'a, Map>,
                         ReadExpect<'a, Point>,
                         ReadExpect<'a, Entity>,
-                        ReadExpect<'a, RunState>,
                         Entities<'a>,
                         WriteStorage<'a, Viewshed>,
                         ReadStorage<'a, Monster>,
@@ -632,7 +631,7 @@ impl<'a> System<'a> for MonsterAI {
                         WriteStorage<'a, WantsToMelee>);
 
     fn run(&mut self, data : Self::SystemData) {
-        let (mut map, player_pos, player_entity, runstate, entities, mut viewshed, monster, mut position, mut wants_to_melee) = data;
+        let (mut map, player_pos, player_entity, entities, mut viewshed, monster, mut position, mut wants_to_melee) = data;
 
         for (entity, mut viewshed,_monster,mut pos) in (&entities, &mut viewshed, &monster, &mut position).join() {
             let distance = rltk::DistanceAlg::Pythagoras.distance2d(Point::new(pos.x, pos.y), *player_pos);


### PR DESCRIPTION
At this stage of the code RunState is still embedded in State and not an entity in the world so it can't be passed over in data. A few sections down when RunState is expanded the proper code is shown there. Running the code at this point will panic otherwise.