### PR TITLE
Remove ConvertSaveLoad from WantsToDropItem

### DIFF
--- a/book/src/chapter_9.md
+++ b/book/src/chapter_9.md
@@ -623,7 +623,7 @@ You probably want to be able to drop items from your inventory, especially later
 
 So we create a component (in `components.rs`), and register it in `main.rs`:
 ```rust
-#[derive(Component, Debug, ConvertSaveload, Clone)]
+#[derive(Component, Debug, Clone)]
 pub struct WantsToDropItem {
     pub item : Entity
 }


### PR DESCRIPTION
Serde doesn't come into scope for 2 more chapters so this just introduces a compile error right now.