### PR TITLE
Remove too early introduced runstate.

### DIFF
--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -624,7 +624,6 @@ impl<'a> System<'a> for MonsterAI {
     type SystemData = ( WriteExpect<'a, Map>,
                         ReadExpect<'a, Point>,
                         ReadExpect<'a, Entity>,
-                        ReadExpect<'a, RunState>,
                         Entities<'a>,
                         WriteStorage<'a, Viewshed>,
                         ReadStorage<'a, Monster>,
@@ -632,7 +631,7 @@ impl<'a> System<'a> for MonsterAI {
                         WriteStorage<'a, WantsToMelee>);
 
     fn run(&mut self, data : Self::SystemData) {
-        let (mut map, player_pos, player_entity, runstate, entities, mut viewshed, monster, mut position, mut wants_to_melee) = data;
+        let (mut map, player_pos, player_entity, entities, mut viewshed, monster, mut position, mut wants_to_melee) = data;
 
         for (entity, mut viewshed,_monster,mut pos) in (&entities, &mut viewshed, &monster, &mut position).join() {
             let distance = rltk::DistanceAlg::Pythagoras.distance2d(Point::new(pos.x, pos.y), *player_pos);


### PR DESCRIPTION
Runstate is introduced later as separate part from state. If existing in remove part it will prevent compiling the code if following the code as the book brogresses.