### PR TITLE
chapter 7: fix diagonal keybindings

### DIFF
--- a/book/src/chapter_7.md
+++ b/book/src/chapter_7.md
@@ -299,10 +299,10 @@ pub fn player_input(gs: &mut State, ctx: &mut Rltk) -> RunState {
 
             // Diagonals
             VirtualKeyCode::Numpad9 |
-            VirtualKeyCode::Y => try_move_player(1, -1, &mut gs.ecs),
+            VirtualKeyCode::U => try_move_player(1, -1, &mut gs.ecs),
 
             VirtualKeyCode::Numpad7 |
-            VirtualKeyCode::U => try_move_player(-1, -1, &mut gs.ecs),
+            VirtualKeyCode::Y => try_move_player(-1, -1, &mut gs.ecs),
 
             VirtualKeyCode::Numpad3 |
             VirtualKeyCode::N => try_move_player(1, 1, &mut gs.ecs),


### PR DESCRIPTION
Swap "Y" and "U" keys to match correct diagonal directions.

The "Y" key on QWERTY layout is supposed to move top-left direction which is Numpad 7. Meanwhile "U" must act as Numpad 9.

Only book contents needs to be updated - source is correct.