### PR TITLE
Fix the file name of the `main_menu` function

### DIFF
--- a/book/src/chapter_11.md
+++ b/book/src/chapter_11.md
@@ -99,7 +99,7 @@ RunState::MainMenu{ .. } => {
 
 We're basically updating the state with the new menu selection, and if something has been selected we change the game state. For `Quit`, we simply terminate the process. For now, we'll make loading/starting a game do the same thing: go into the `PreRun` state to setup the game.
 
-The last thing to do is to write the menu itself. In `menu.rs`:
+The last thing to do is to write the menu itself. In `gui.rs`:
 
 ```rust
 pub fn main_menu(gs : &mut State, ctx : &mut Rltk) -> MainMenuResult {


### PR DESCRIPTION
The `main_manu` function is defined in `gui.rs`, and there are no `menu.rs` .

I didn't modify the last line, but GitHub did it without asking.